### PR TITLE
Sort NMP and VMPGroups alphabetically

### DIFF
--- a/sam/src/main/kotlin/org/taktik/icure/asyncdao/samv2/impl/NmpDAOImpl.kt
+++ b/sam/src/main/kotlin/org/taktik/icure/asyncdao/samv2/impl/NmpDAOImpl.kt
@@ -52,6 +52,8 @@ class NmpDAOImpl(
 	override fun findNmpsByLabel(datastoreInformation: IDatastoreInformation, language: String?, label: String?, paginationOffset: PaginationOffset<List<String>>): Flow<ViewQueryResultEvent> = flow {
 		require(label != null && label.length >= 3) { "Label must be at least 3 characters long" }
 		val rowIds = coroutineScope {
+			//TODO check the relevance of using a SupervisorScope to avoid failure on parallel cancellation
+			//TODO Use Pair<Long,Long> for key (SHA) and it
 			cache.get(label) { key, _ ->
 				future {
 					val client = couchDbDispatcher.getClient(datastoreInformation)

--- a/sam/src/main/kotlin/org/taktik/icure/asyncdao/samv2/impl/NmpDAOImpl.kt
+++ b/sam/src/main/kotlin/org/taktik/icure/asyncdao/samv2/impl/NmpDAOImpl.kt
@@ -4,14 +4,21 @@
 
 package org.taktik.icure.asyncdao.samv2.impl
 
+import com.github.benmanes.caffeine.cache.Caffeine
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Repository
 import org.taktik.couchdb.ViewQueryResultEvent
+import org.taktik.couchdb.ViewRowNoDoc
+import org.taktik.couchdb.ViewRowWithDoc
 import org.taktik.couchdb.annotation.View
 import org.taktik.couchdb.dao.DesignDocumentProvider
 import org.taktik.couchdb.entity.ComplexKey
@@ -26,6 +33,9 @@ import org.taktik.icure.asynclogic.datastore.IDatastoreInformation
 import org.taktik.icure.db.PaginationOffset
 import org.taktik.icure.db.sanitizeString
 import org.taktik.icure.entities.samv2.Nmp
+import org.taktik.icure.utils.makeFromTo
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 @Repository("nmpDAO")
 @Profile("sam")
@@ -36,26 +46,28 @@ class NmpDAOImpl(
 	datastoreInstanceProvider: DatastoreInstanceProvider,
 	designDocumentProvider: DesignDocumentProvider
 ) : InternalDAOImpl<Nmp>(Nmp::class.java, couchDbDispatcher, idGenerator, datastoreInstanceProvider, designDocumentProvider), NmpDAO {
+	val cache = Caffeine.newBuilder().maximumSize(1000).expireAfterAccess(1.minutes.toJavaDuration()).buildAsync<String, List<String>>()
+
 	@View(name = "by_language_label", map = "classpath:js/nmp/By_language_label.js")
 	override fun findNmpsByLabel(datastoreInformation: IDatastoreInformation, language: String?, label: String?, paginationOffset: PaginationOffset<List<String>>): Flow<ViewQueryResultEvent> = flow {
-		val client = couchDbDispatcher.getClient(datastoreInformation)
-		val sanitizedLabel = label?.let { sanitizeString(it) }
-		val from = ComplexKey.of(
-			language ?: "\u0000",
-			sanitizedLabel ?: "\u0000"
-		)
-		val to = ComplexKey.of(
-			language ?: ComplexKey.emptyObject(),
-			if (sanitizedLabel == null) ComplexKey.emptyObject() else sanitizedLabel + "\ufff0"
-		)
-		val viewQuery = pagedViewQuery(
-			"by_language_label",
-			from,
-			to,
-			paginationOffset.toPaginationOffset { sk -> ComplexKey.of(*sk.mapIndexed { i, s -> if (i == 1) sanitizeString(s) else s }.toTypedArray()) },
-			false
-		)
-		emitAll(client.queryView(viewQuery, ComplexKey::class.java, String::class.java, Nmp::class.java))
+		require(label != null && label.length >= 3) { "Label must be at least 3 characters long" }
+		val rowIds = coroutineScope {
+			cache.get(label) { key, _ ->
+				future {
+					val client = couchDbDispatcher.getClient(datastoreInformation)
+					makeFromTo(key, language).let { (from, to) ->
+						val viewQuery = createQuery("by_language_label")
+							.startKey(from)
+							.endKey(to)
+							.reduce(false)
+							.includeDocs(false)
+						client.queryView<ComplexKey, String>(viewQuery).toList().sortedBy { it.value }.map { it.id }
+					}
+				}
+			}.await()
+		}
+
+		emitAll(getEntities(rowIds.asSequence().let { seq -> paginationOffset.startDocumentId?.let { start -> seq.dropWhile { it != start } } ?: seq }.take(paginationOffset.limit).toList()).map { ViewRowWithDoc(it.id, ComplexKey.of(language, ""), "", it) })
 	}
 
 	override fun listNmpIdsByLabel(datastoreInformation: IDatastoreInformation, language: String?, label: String?): Flow<String> = flow {

--- a/sam/src/main/kotlin/org/taktik/icure/asyncdao/samv2/impl/VmpGroupDAOImpl.kt
+++ b/sam/src/main/kotlin/org/taktik/icure/asyncdao/samv2/impl/VmpGroupDAOImpl.kt
@@ -4,12 +4,18 @@
 
 package org.taktik.icure.asyncdao.samv2.impl
 
+import com.github.benmanes.caffeine.cache.Caffeine
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.future.await
+import kotlinx.coroutines.future.future
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Repository
+import org.taktik.couchdb.ViewRowWithDoc
 import org.taktik.couchdb.annotation.View
 import org.taktik.couchdb.dao.DesignDocumentProvider
 import org.taktik.couchdb.entity.ComplexKey
@@ -25,6 +31,8 @@ import org.taktik.icure.db.PaginationOffset
 import org.taktik.icure.db.sanitizeString
 import org.taktik.icure.entities.samv2.VmpGroup
 import org.taktik.icure.utils.makeFromTo
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 @Repository("vmpGroupDAO")
 @Profile("sam")
@@ -35,6 +43,8 @@ class VmpGroupDAOImpl(
 	datastoreInstanceProvider: DatastoreInstanceProvider,
 	designDocumentProvider: DesignDocumentProvider
 ) : InternalDAOImpl<VmpGroup>(VmpGroup::class.java, couchDbDispatcher, idGenerator, datastoreInstanceProvider, designDocumentProvider), VmpGroupDAO {
+	val cache = Caffeine.newBuilder().maximumSize(1000).expireAfterAccess(1.minutes.toJavaDuration()).buildAsync<String, List<String>>()
+
 	@View(name = "by_groupcode", map = "classpath:js/vmpgroup/By_groupcode.js")
 	override fun findVmpGroupsByVmpGroupCode(datastoreInformation: IDatastoreInformation, vmpgCode: String, paginationOffset: PaginationOffset<String>) = flow {
 		val client = couchDbDispatcher.getClient(datastoreInformation)
@@ -60,21 +70,24 @@ class VmpGroupDAOImpl(
 
 	@View(name = "by_language_label", map = "classpath:js/vmpgroup/By_language_label.js")
 	override fun findVmpGroupsByLabel(datastoreInformation: IDatastoreInformation, language: String?, label: String?, paginationOffset: PaginationOffset<List<String>>) = flow {
-		val client = couchDbDispatcher.getClient(datastoreInformation)
-		emitAll(
-			makeFromTo(label, language).let { (from, to) ->
-				client.queryView(
-					pagedViewQuery(
-						"by_language_label",
-						from,
-						to,
-						paginationOffset.toPaginationOffset { sk -> ComplexKey.of(*sk.mapIndexed { i, s -> if (i == 1) sanitizeString(s) else s }.toTypedArray()) },
-						false
-					),
-					ComplexKey::class.java, String::class.java, VmpGroup::class.java
-				)
+		require(label != null && label.length >= 3) { "Label must be at least 3 characters long" }
+		val rowIds = coroutineScope {
+			cache.get(label) { key, _ ->
+				future {
+					val client = couchDbDispatcher.getClient(datastoreInformation)
+					makeFromTo(key, language).let { (from, to) ->
+						val viewQuery = createQuery("by_language_label")
+							.startKey(from)
+							.endKey(to)
+							.reduce(false)
+							.includeDocs(false)
+						client.queryView<ComplexKey, String>(viewQuery).toList().sortedBy { it.value }.map { it.id }
+					}
+				}
 			}
-		)
+		}.await()
+
+		emitAll(getEntities(rowIds.asSequence().let { seq -> paginationOffset.startDocumentId?.let { start -> seq.dropWhile { it != start } } ?: seq }.take(paginationOffset.limit).toList()).map { ViewRowWithDoc(it.id, ComplexKey.of(language, ""), "", it) })
 	}
 
 	override fun listVmpGroupIdsByLabel(datastoreInformation: IDatastoreInformation, language: String?, label: String?) = flow {

--- a/sam/src/main/resources/org/taktik/icure/asyncdao/samv2/impl/js/nmp/By_language_label.js
+++ b/sam/src/main/resources/org/taktik/icure/asyncdao/samv2/impl/js/nmp/By_language_label.js
@@ -35,11 +35,10 @@ map = function(doc) {
             "ʐ":"z","ƶ":"z","ɀ":"z","ﬀ":"ff","ﬃ":"ffi","ﬄ":"ffl","ﬁ":"fi","ﬂ":"fl","ĳ":"ij","œ":"oe","ﬆ":"st","ₐ":"a","ₑ":"e","ᵢ":"i","ⱼ":"j",
             "ₒ":"o","ᵣ":"r","ᵤ":"u","ᵥ":"v","ₓ":"x"};
         var wordsPerLanguage = {};
-        var stub = {name:doc.name};
         (["name"]).forEach(function(k) {
-            Object.keys(stub[k]||{}).forEach(function (l) {
-                if (stub[k][l]) {
-                    wordsPerLanguage[l] = (wordsPerLanguage[l]||[]).concat(normalize_substrings(stub[k][l], latin_map))
+            Object.keys(doc[k]||{}).forEach(function (l) {
+                if (doc[k][l]) {
+                    wordsPerLanguage[l] = (wordsPerLanguage[l]||[]).concat(normalize_substrings(doc[k][l], latin_map))
                 }
             })
         })
@@ -47,7 +46,7 @@ map = function(doc) {
             var terms = wordsPerLanguage[l]
             terms.sort().forEach(function (t, idx) {
                 if (idx === terms.length - 1 || !(terms[idx + 1].indexOf(t) === 0)) {
-                    emit([l, t], 1)
+                    emit([l, t], doc.name[l])
                 }
             })
         })

--- a/sam/src/main/resources/org/taktik/icure/asyncdao/samv2/impl/js/vmpgroup/By_language_label.js
+++ b/sam/src/main/resources/org/taktik/icure/asyncdao/samv2/impl/js/vmpgroup/By_language_label.js
@@ -44,7 +44,7 @@ map = function(doc) {
             var terms = wordsPerLanguage[l]
             terms.sort().forEach(function (t, idx) {
                 if (idx === terms.length - 1 || !(terms[idx + 1].indexOf(t) === 0)) {
-                    emit([l, t], 1)
+                    emit([l, t], doc.name[l])
                 }
             })
         })


### PR DESCRIPTION
The actual key on which the alphabetical order must happen has been added to the views as a value. The value used to be a 1 and is now a string but in the code the value was already a string.

The DAO has been changed. A list of ids is obtained first, sorted by value and cached for pagination purposes. The documents in the paginated window are loaded.